### PR TITLE
Fix parsing error in ugen_lookup

### DIFF
--- a/util/ugen_lookup
+++ b/util/ugen_lookup
@@ -15,7 +15,7 @@ echo "$REF does not exist!"
 exit 1
 fi
 
-LINES=$(grep -r -n "^Name:" $REF | egrep "$NAME" | cut -d ':' -f 1 | sed "s/\n/ /g")
+LINES=$(grep -r -n "^Name:" $REF | egrep "$NAME" | cut -d ':' -f 2 | sed "s/\n/ /g")
 
 if [ -z "$LINES" ]
 then

--- a/util/ugen_lookup
+++ b/util/ugen_lookup
@@ -6,6 +6,7 @@ exit 1
 fi
 
 NAME=$1
+OS="$(uname)"
 
 REF=/usr/local/share/sporth/ugen_reference.txt
 
@@ -15,7 +16,18 @@ echo "$REF does not exist!"
 exit 1
 fi
 
-LINES=$(grep -r -n "^Name:" $REF | egrep "$NAME" | cut -d ':' -f 2 | sed "s/\n/ /g")
+if [ "$OS" = "Linux" ]
+then
+FIELD=1
+elif [ "$OS" = "Darwin" ]
+then
+FIELD=2
+else
+echo "Requires macOS or Linux."
+exit 1
+fi
+
+LINES=$(grep -r -n "^Name:" $REF | egrep "$NAME" | cut -d ':' -f "$FIELD" | sed "s/\n/ /g")
 
 if [ -z "$LINES" ]
 then


### PR DESCRIPTION
I get an error from `cut -d ':' -f 1` on macOS (not 100% certain this is a bug on linux) because it returns the text before the `:`.

```
ugen_lookup jitter

(standard_in) 1: parse error
(standard_in) 1: parse error
sed: 1: "/usr/local/share/sporth ...": extra characters at the end of l command
```